### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install karma-clear-screen-reporter --save-dev
 ```
 
 ## Configuration
-Play it safe to load this plugin both in your reporters and plugins.
+Play it safe to load this plugin both in your reporters and plugins, if you are already having a plugins section. Karama loads automatically all available plugins from your node modules as long as you have not declared them explicitly. For more details please read the [Loading Plugins](http://karma-runner.github.io/0.13/config/plugins.html) by Karma.
 ```js
 // karma.conf.js
 module.exports = function(config) {


### PR DESCRIPTION
Sorry dude, have learned today something new from this [post](http://stackoverflow.com/questions/19069183/karma-throws-error-can-not-load-ng-html2js-it-is-not-registered#answer-31462845) on stackoverflow.

So it is NOT necessary to put the plugin explicitly to the plugins section, as long as you omit it completely. Karma loads them automatically from your node module folder.
