### PR TITLE
Clearing screen and removing scroll back

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 function ClearScreenReporter() {
   this.onRunStart = function() {
     console.log("\u001b[2J\u001b[0;0H");
+    console.log("\u001b[3J")
   };
 }
 


### PR DESCRIPTION
The functionality I was seeking was not just to do a "clear" on screen, but also to remove the scroll back so only the most recent tests are displayed.  Perhaps this should not be automatically merged as some people may prefer to have a history, but perhaps this can be configurable in the module.

The command to clear scrollback was outlined here:

http://apple.stackexchange.com/questions/31872/how-do-i-reset-the-scrollback-in-the-terminal-via-a-shell-command
